### PR TITLE
Fixed error with page load handler.

### DIFF
--- a/src/content_script/message_handling.js
+++ b/src/content_script/message_handling.js
@@ -7,7 +7,7 @@ function _glpInit() {
 _glpInit();
 
 // Send contexts whenever page is loaded
-document.addEventListener("DOMContentLoaded", setTimeout(glpContexts.sendContexts, 500));
+document.addEventListener("DOMContentLoaded", () => setTimeout(glpContexts.sendContexts, 500));
 
 /**
  * Receive messages from the devtools panel


### PR DESCRIPTION
Line 10 was triggering "TypeError: Failed to execute 'addEventListener' on 'EventTarget': The callback provided as parameter 2 is not an object."